### PR TITLE
refactor(core): centralize shared command logic(burn/recovery) and introduce RuntimeContext

### DIFF
--- a/src/cli/burn.rs
+++ b/src/cli/burn.rs
@@ -1,8 +1,8 @@
 use super::CommonOpt;
+use crate::cli::utils::check_required_files;
 use crate::fp::{Fp, FpRepr};
 use crate::poseidon2::poseidon2;
-use crate::utils::BETH;
-use crate::utils::{RapidsnarkOutput, find_burn_key, generate_burn_address, input_file};
+use crate::utils::{RapidsnarkOutput, find_burn_key, generate_burn_address};
 use alloy::rlp::Encodable;
 use alloy::{
     eips::BlockId,
@@ -12,7 +12,7 @@ use alloy::{
         B256, U256,
         utils::{format_ether, parse_ether},
     },
-    providers::{Provider, ProviderBuilder},
+    providers::Provider,
     rpc::types::TransactionRequest,
 };
 use anyhow::anyhow;
@@ -34,24 +34,11 @@ pub struct BurnOpt {
 
 impl BurnOpt {
     pub async fn run(self, params_dir: &std::path::Path) -> Result<(), anyhow::Error> {
-        let net = self.common_opt.overridden_network()?;
-
-        let required_files = [
-            "proof_of_burn.dat",
-            "proof_of_burn.zkey",
-            "spend.dat",
-            "spend.zkey",
-        ];
-
-        for req_file in required_files {
-            let full_path = params_dir.join(req_file);
-            if !std::fs::exists(&full_path)? {
-                panic!(
-                    "File {} does not exist! Make sure you have downloaded all required files through `make download_params`!",
-                    full_path.display()
-                );
-            }
-        }
+        check_required_files(params_dir)?;
+        let runtime_context = self.common_opt.setup().await?;
+        let net = runtime_context.network;
+        let provider = runtime_context.provider;
+        let wallet_addr = runtime_context.wallet_address;
 
         let fee = parse_ether(&self.fee)?;
         let spend = parse_ether(&self.spend)?;
@@ -65,16 +52,6 @@ impl BurnOpt {
             return Err(anyhow!(
                 "Sum of --fee and --spend should be less than --amount!"
             ));
-        }
-
-        let wallet_addr = self.common_opt.private_key.address();
-
-        let provider = ProviderBuilder::new()
-            .wallet(self.common_opt.private_key)
-            .connect_http(net.rpc.clone());
-
-        if provider.get_code_at(net.beth).await?.0.is_empty() {
-            panic!("BETH contract does not exist!");
         }
 
         println!("Generating a burn-key...");
@@ -125,18 +102,25 @@ impl BurnOpt {
             .await?
             .ok_or(anyhow!("Block not found!"))?;
         println!("Generated proof for block #{}", block.header.number);
-        let mut header_bytes = Vec::new();
-        block.header.inner.encode(&mut header_bytes);
-        let proof = provider.get_proof(burn_addr, vec![]).await?;
 
         let input_json_path = "input.json";
-        let witness_path = "witness.wtns";
-
+        let mut header_bytes = Vec::new();
+        block.header.inner.encode(&mut header_bytes);
         println!("Generating input.json file at: {}", input_json_path);
-        std::fs::write(
-            &input_json_path,
-            input_file(proof, header_bytes, burn_key, fee, spend, wallet_addr)?.to_string(),
-        )?;
+        self.common_opt
+            .generate_input_file(
+                &provider,
+                header_bytes,
+                burn_addr,
+                burn_key,
+                fee,
+                spend,
+                wallet_addr,
+                input_json_path,
+            )
+            .await?;
+
+        let witness_path = "witness.wtns";
 
         let proc_path = std::env::current_exe().expect("Failed to get current exe path");
 
@@ -160,53 +144,41 @@ impl BurnOpt {
 
         println!("Generating proof...");
         let output = Command::new(&proc_path)
-                .arg("rapidsnark")
-                .arg("--zkey")
-                .arg(params_dir.join("proof_of_burn.zkey"))
-                .arg("--witness")
-                .arg(witness_path)
-                .output()?;
-        
+            .arg("rapidsnark")
+            .arg("--zkey")
+            .arg(params_dir.join("proof_of_burn.zkey"))
+            .arg("--witness")
+            .arg(witness_path)
+            .output()?;
+
         output.status.success().then_some(()).ok_or_else(|| {
             anyhow!(
                 "Failed to generate proof: {}",
                 String::from_utf8_lossy(&output.stderr)
             )
         })?;
-        let json_output: RapidsnarkOutput = serde_json::from_slice(
-            &output.stdout
-
-        )?;
-        
+        let json_output: RapidsnarkOutput = serde_json::from_slice(&output.stdout)?;
         println!("Generated proof successfully! {:?}", output);
 
+        let nullifier_u256 = U256::from_le_bytes(nullifier.to_repr().0);
+        let remaining_coin_u256 = U256::from_le_bytes(remaining_coin.to_repr().0);
+
         println!("Broadcasting mint transaction...");
-        let beth = BETH::new(net.beth, provider);
-        let mint_receipt = beth
-            .mintCoin(
-                [json_output.proof.pi_a[0], json_output.proof.pi_a[1]],
-                [
-                    [json_output.proof.pi_b[0][1], json_output.proof.pi_b[0][0]],
-                    [json_output.proof.pi_b[1][1], json_output.proof.pi_b[1][0]],
-                ],
-                [json_output.proof.pi_c[0], json_output.proof.pi_c[1]],
-                U256::from(block.header.number),
-                U256::from_le_bytes(nullifier.to_repr().0),
-                U256::from_le_bytes(remaining_coin.to_repr().0),
+        let _result = self
+            .common_opt
+            .broadcast_mint(
+                &net,
+                provider,
+                &json_output,        // RapidsnarkOutput
+                block.header.number, // u64
+                nullifier_u256,
+                remaining_coin_u256,
                 fee,
                 spend,
                 wallet_addr,
             )
-            .send()
-            .await?
-            .get_receipt()
-            .await?;
+            .await;
 
-        if mint_receipt.status() {
-            println!("Success!");
-        } else {
-            println!("Transaction failed!");
-        }
         Ok(())
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -5,11 +5,21 @@ mod info;
 mod mine;
 mod participate;
 mod recover;
-
-use alloy::signers::local::PrivateKeySigner;
+mod utils;
+use crate::utils::{RapidsnarkOutput, input_file};
+use alloy::{signers::local::PrivateKeySigner};
 use anyhow::anyhow;
 use reqwest::Url;
 use structopt::StructOpt;
+
+use alloy::{
+    primitives::{
+        Address, U256,
+    },
+    providers::{Provider, ProviderBuilder},
+};
+
+use anyhow::Result;
 
 #[derive(StructOpt)]
 pub struct CommonOpt {
@@ -19,6 +29,16 @@ pub struct CommonOpt {
     private_key: PrivateKeySigner,
     #[structopt(long)]
     custom_rpc: Option<Url>,
+}
+use crate::fp::{Fp,};
+use crate::utils::BETH;
+use std::path::Path;
+
+#[derive(Debug)]
+pub struct RuntimeContext<P: Provider> {
+    pub network: Network,
+    pub wallet_address: Address,
+    pub provider: P,
 }
 
 impl CommonOpt {
@@ -32,8 +52,101 @@ impl CommonOpt {
         }
         Ok(net)
     }
+    pub async fn setup(&self) -> Result<RuntimeContext<impl Provider>, anyhow::Error> {
+        let mut net = NETWORKS
+            .get(&self.network)
+            .ok_or(anyhow!("Network not found!"))?
+            .clone();
+        if let Some(custom_rpc) = &self.custom_rpc {
+            net.rpc = custom_rpc.clone();
+        }
+        let wallet_addr = self.private_key.address();
+        let provider = ProviderBuilder::new()
+            .wallet(self.private_key.clone())
+            .connect_http(net.rpc.clone());
+        if provider.get_code_at(net.beth).await?.0.is_empty() {
+            panic!("BETH contract does not exist!");
+        }
+        Ok(RuntimeContext {
+            network: net,
+            wallet_address: wallet_addr,
+            provider,
+        })
+    }
+
+    pub async fn broadcast_mint<P: Provider>(
+        &self,
+        net: &Network,
+        provider: P,
+        proof: &RapidsnarkOutput,
+        block_number: u64,
+        nullifier: U256,
+        remaining_coin: U256,
+        fee: U256,
+        spend: U256,
+        wallet_addr: Address,
+    ) -> Result<()> {
+        println!("Broadcasting mint transaction...");
+        // instantiate your BETH binding
+        let beth = BETH::new(net.beth, provider);
+
+        // call the zk-proof mintCoin(...) method
+        let receipt = beth
+            .mintCoin(
+                // pi_a
+                [proof.proof.pi_a[0], proof.proof.pi_a[1]],
+                // pi_b (flipped coordinates)
+                [
+                    [proof.proof.pi_b[0][1], proof.proof.pi_b[0][0]],
+                    [proof.proof.pi_b[1][1], proof.proof.pi_b[1][0]],
+                ],
+                // pi_c
+                [proof.proof.pi_c[0], proof.proof.pi_c[1]],
+                // block number as U256
+                U256::from(block_number),
+                // nullifier & remaining_coin
+                nullifier,
+                remaining_coin,
+                // fee & spend
+                fee,
+                spend,
+                // user’s address
+                wallet_addr,
+            )
+            .send()
+            .await?
+            .get_receipt()
+            .await?;
+
+        if receipt.status() {
+            println!("Success!");
+        } else {
+            println!("Transaction failed!");
+        }
+        Ok(())
+    }
+
+    pub async fn generate_input_file<P: Provider>(
+        &self,
+        provider: &P,
+        header_bytes: Vec<u8>,
+        burn_addr: Address,
+        burn_key: Fp,
+        fee: U256,
+        spend: U256,
+        wallet_addr: Address,
+        input_path: impl AsRef<Path>,
+    ) -> Result<()> {
+        let proof = provider.get_proof(burn_addr, vec![]).await?;
+        let json = input_file(proof, header_bytes, burn_key, fee, spend, wallet_addr)?.to_string();
+        let path = input_path.as_ref();
+        println!("Generating input.json file at: {}", path.display());
+        std::fs::write(path, json)?;
+        Ok(())
+    }
 }
 
+use crate::networks::{NETWORKS, Network};
 pub use burn::BurnOpt;
 pub use claim::ClaimOpt;
 pub use generate_witness::GenerateWitnessOpt;
@@ -41,5 +154,3 @@ pub use info::InfoOpt;
 pub use mine::MineOpt;
 pub use participate::ParticipateOpt;
 pub use recover::RecoverOpt;
-
-use crate::networks::{NETWORKS, Network};

--- a/src/cli/recover.rs
+++ b/src/cli/recover.rs
@@ -3,16 +3,16 @@ use structopt::StructOpt;
 use std::process::Command;
 
 use super::CommonOpt;
+use crate::cli::utils::check_required_files;
 use crate::fp::{Fp, FpRepr};
 use crate::poseidon2::poseidon2;
-use crate::utils::BETH;
-use crate::utils::{RapidsnarkOutput, generate_burn_address, input_file};
+use crate::utils::{RapidsnarkOutput, generate_burn_address};
 use alloy::rlp::Encodable;
 use alloy::{
     eips::BlockId,
     hex::ToHexExt,
     primitives::{B256, U256},
-    providers::{Provider, ProviderBuilder},
+    providers::{Provider},
 };
 use anyhow::anyhow;
 use ff::{Field, PrimeField};
@@ -27,34 +27,11 @@ pub struct RecoverOpt {
 
 impl RecoverOpt {
     pub async fn run(self, params_dir: &std::path::Path) -> Result<(), anyhow::Error> {
-        let net = self.common_opt.overridden_network()?;
-
-        let required_files = [
-            "proof_of_burn.dat",
-            "proof_of_burn.zkey",
-            "spend.dat",
-            "spend.zkey",
-        ];
-
-        for req_file in required_files {
-            let full_path = params_dir.join(req_file);
-            if !std::fs::exists(&full_path)? {
-                panic!(
-                    "File {} does not exist! Make sure you have downloaded all required files through `make download_params`!",
-                    full_path.display()
-                );
-            }
-        }
-
-        let wallet_addr = self.common_opt.private_key.address();
-
-        let provider = ProviderBuilder::new()
-            .wallet(self.common_opt.private_key)
-            .connect_http(net.rpc.clone());
-
-        if provider.get_code_at(net.beth).await?.0.is_empty() {
-            panic!("BETH contract does not exist!");
-        }
+        check_required_files(params_dir)?;
+        let runtime_context = self.common_opt.setup().await?;
+        let net = runtime_context.network;
+        let provider = runtime_context.provider;
+        let wallet_addr = runtime_context.wallet_address;
 
         println!("Generating a burn-key...");
         let burn_key = Fp::from_repr(FpRepr(
@@ -71,6 +48,8 @@ impl RecoverOpt {
         if burn_addr_balance.is_zero() {
             panic!("No ETH is present in the burn address!");
         }
+        let fee = U256::ZERO;
+        let spend = burn_addr_balance;
 
         let remaining_coin = poseidon2([burn_key, Fp::ZERO]);
 
@@ -84,32 +63,32 @@ impl RecoverOpt {
             .get_block(BlockId::latest())
             .await?
             .ok_or(anyhow!("Block not found!"))?;
+
         println!("Generated proof for block #{}", block.header.number);
-        let mut header_bytes = Vec::new();
-        block.header.inner.encode(&mut header_bytes);
-        let proof = provider.get_proof(burn_addr, vec![]).await?;
 
         let input_json_path = "input.json";
-        let witness_path = "witness.wtns"; //proof_dir.path().join("witness.wtns");
-
+        let mut header_bytes = Vec::new();
+        block.header.inner.encode(&mut header_bytes);
         println!("Generating input.json file at: {}", input_json_path);
-        std::fs::write(
-            &input_json_path,
-            input_file(
-                proof,
+        self.common_opt
+            .generate_input_file(
+                &provider,
                 header_bytes,
+                burn_addr,
                 burn_key,
-                U256::ZERO,
-                burn_addr_balance,
+                fee,
+                spend,
                 wallet_addr,
-            )?
-            .to_string(),
-        )?;
+                input_json_path,
+            )
+            .await?;
+
+        let witness_path = "witness.wtns"; //proof_dir.path().join("witness.wtns");
 
         let proc_path = std::env::current_exe().expect("Failed to get current exe path");
 
         println!("Generating witness.wtns file at: {}", witness_path);
-        Command::new(&proc_path)
+        let output = Command::new(&proc_path)
             .arg("generate-witness")
             .arg("proof-of-burn")
             .arg("--input")
@@ -120,47 +99,49 @@ impl RecoverOpt {
             .arg(witness_path)
             .output()?;
 
+        output.status.success().then_some(()).ok_or_else(|| {
+            anyhow!(
+                "Failed to generate witness file: {}",
+                String::from_utf8_lossy(&output.stderr)
+            )
+        })?;
         println!("Generating proof...");
-        let output: RapidsnarkOutput = serde_json::from_slice(
-            &Command::new(&proc_path)
-                .arg("rapidsnark")
-                .arg("--zkey")
-                .arg(params_dir.join("proof_of_burn.zkey"))
-                .arg("--witness")
-                .arg(witness_path)
-                .output()?
-                .stdout,
-        )?;
+        let output = Command::new(&proc_path)
+            .arg("rapidsnark")
+            .arg("--zkey")
+            .arg(params_dir.join("proof_of_burn.zkey"))
+            .arg("--witness")
+            .arg(witness_path)
+            .output()?;
 
+        output.status.success().then_some(()).ok_or_else(|| {
+            anyhow!(
+                "Failed to generate proof: {}",
+                String::from_utf8_lossy(&output.stderr)
+            )
+        })?;
+
+        let json_output: RapidsnarkOutput = serde_json::from_slice(&output.stdout)?;
         println!("Generated proof successfully! {:?}", output);
 
+        let nullifier_u256 = U256::from_le_bytes(nullifier.to_repr().0);
+        let remaining_coin_u256 = U256::from_le_bytes(remaining_coin.to_repr().0);
+
         println!("Broadcasting mint transaction...");
-        let beth = BETH::new(net.beth, provider);
-        let mint_receipt = beth
-            .mintCoin(
-                [output.proof.pi_a[0], output.proof.pi_a[1]],
-                [
-                    [output.proof.pi_b[0][1], output.proof.pi_b[0][0]],
-                    [output.proof.pi_b[1][1], output.proof.pi_b[1][0]],
-                ],
-                [output.proof.pi_c[0], output.proof.pi_c[1]],
-                U256::from(block.header.number),
-                U256::from_le_bytes(nullifier.to_repr().0),
-                U256::from_le_bytes(remaining_coin.to_repr().0),
-                U256::ZERO,
-                burn_addr_balance,
+        let _result = self
+            .common_opt
+            .broadcast_mint(
+                &net,
+                provider,
+                &json_output,        // RapidsnarkOutput
+                block.header.number, // u64
+                nullifier_u256,
+                remaining_coin_u256,
+                fee,
+                spend,
                 wallet_addr,
             )
-            .send()
-            .await?
-            .get_receipt()
-            .await?;
-
-        if mint_receipt.status() {
-            println!("Success!");
-        } else {
-            println!("Transaction failed!");
-        }
+            .await;
 
         Ok(())
     }

--- a/src/cli/utils.rs
+++ b/src/cli/utils.rs
@@ -1,0 +1,19 @@
+pub fn check_required_files(params_dir: &std::path::Path) -> Result<(), anyhow::Error> {
+    let required_files = [
+        "proof_of_burn.dat",
+        "proof_of_burn.zkey",
+        "spend.dat",
+        "spend.zkey",
+    ];
+
+    for req_file in required_files {
+        let full_path = params_dir.join(req_file);
+        if !std::fs::exists(&full_path)? {
+            panic!(
+                "File {} does not exist! Make sure you have downloaded all required files through `make download_params`!",
+                full_path.display()
+            );
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
This patch refactors both the Burn and Recover commands to eliminate duplication and improve maintainability:

1. **Extract file‐existence checks**  
   - Moved the loop that validates `proof_of_burn.dat`, `proof_of_burn.zkey`, `spend.dat` and `spend.zkey` into  
     `utils::check_required_files(params_dir)`.

2. **Centralize mint broadcast**  
   - Pulled the `BETH::mintCoin(…)` invocation plus success/failure logging into  
     `CommonOpt::broadcast_mint(...)`.

3. **Unify input.json generation**  
   - Moved header encoding, `get_proof`, and `input_file(…)` → write → logging into  
     `CommonOpt::generate_input_file(...)`.

4. **Introduce `RuntimeContext`**  
   - New struct `{ network, wallet_address, provider }`  
   - Instantiated in `CommonOpt::setup()` (using `impl Provider`)  
   - Both `BurnOpt::run` and `RecoverOpt::run` now consume a `RuntimeContext` instead of repeating setup code.

