### PR TITLE
docker: fix build on macos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ========= Stage 1: Build rapidsnark =========
-FROM debian:bookworm-slim AS rapidsnark-builder
+FROM --platform=linux/amd64 debian:bookworm-slim AS rapidsnark-builder
 WORKDIR /src
 
 # Install build dependencies for rapidsnark
@@ -43,7 +43,7 @@ RUN git clone https://github.com/worm-privacy/witness && \
     make all
 
 # ========= Stage 3: Build Rust worm-miner =========
-FROM rustlang/rust:nightly-bookworm AS rust-builder
+FROM --platform=linux/amd64 rustlang/rust:nightly-bookworm AS rust-builder
 WORKDIR /src
 
 # Install additional dependencies for Rust build
@@ -95,7 +95,7 @@ ENV CARGO_UNSTABLE_EDITION2024=true
 RUN cargo +nightly build --release
 
 # ========= Stage 4: Final runtime image =========
-FROM debian:bookworm-slim
+FROM --platform=linux/amd64 debian:bookworm-slim
 WORKDIR /app
 
 # Runtime dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # ========= Stage 1: Build rapidsnark =========
-FROM --platform=linux/amd64 debian:bookworm-slim AS rapidsnark-builder
+ARG BUILDPLATFORM=linux/amd64
+FROM --platform=${BUILDPLATFORM} debian:bookworm-slim AS rapidsnark-builder
 WORKDIR /src
 
 # Install build dependencies for rapidsnark
@@ -43,7 +44,8 @@ RUN git clone https://github.com/worm-privacy/witness && \
     make all
 
 # ========= Stage 3: Build Rust worm-miner =========
-FROM --platform=linux/amd64 rustlang/rust:nightly-bookworm AS rust-builder
+ARG BUILDPLATFORM=linux/amd64
+FROM --platform=${BUILDPLATFORM} rustlang/rust:nightly-bookworm AS rust-builder
 WORKDIR /src
 
 # Install additional dependencies for Rust build
@@ -95,7 +97,8 @@ ENV CARGO_UNSTABLE_EDITION2024=true
 RUN cargo +nightly build --release
 
 # ========= Stage 4: Final runtime image =========
-FROM --platform=linux/amd64 debian:bookworm-slim
+ARG BUILDPLATFORM=linux/amd64
+FROM --platform=${BUILDPLATFORM} debian:bookworm-slim
 WORKDIR /app
 
 # Runtime dependencies


### PR DESCRIPTION
Without explicitly specifying the docker platform, the build fails on macos in the following way:

```
$ uname -m
arm64

$ sw_vers
ProductName:		macOS
ProductVersion:		15.6.1
BuildVersion:		24G90

$ docker build -t worm-miner .

...

/usr/bin/ld: libfq.a(fq_asm.o): Relocations in generic ELF (EM: 62)
/usr/bin/ld: libfq.a: error adding symbols: file in wrong format
```